### PR TITLE
Edit default Next.js home page description

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Home",
-  description: "Welcome to Next.js",
+  description: "Student reviews for OMS courses.",
 };
 
 export default function RootLayout({ children }: PropsWithChildren) {


### PR DESCRIPTION
When sharing this site, the link preview looks like:

![image](https://github.com/user-attachments/assets/b3d31008-1cd3-459d-a773-41ea86142a76)

This will update the default Next.js text.